### PR TITLE
Added 50 minutes to zenith

### DIFF
--- a/SunCalPlayground.playground/section-1.swift
+++ b/SunCalPlayground.playground/section-1.swift
@@ -99,7 +99,7 @@ let event = SunEvent.SunEventSet
 // calculation of Julian Day Number (http://en.wikipedia.org/wiki/Julian_day ) from Gregorian Date
 let calendar = NSCalendar(calendarIdentifier: NSCalendarIdentifierGregorian)!
 
-let zenith = 90.0
+let zenith = 90.0 + 50.0/60.0
 
 let components = calendar.components(.CalendarUnitYear | .CalendarUnitMonth | .CalendarUnitDay | .CalendarUnitTimeZone , fromDate: inDate)
 


### PR DESCRIPTION
Official sunset is 90 degrees 50 minutes according to https://github.com/asadoughi/SunCalPlayground/blob/1881237ad60878071712b59baa1d82c7944807c9/SunCalPlayground.playground/section-1.swift#L13

In practice, this corrected my computations.
